### PR TITLE
8 tag search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 secrets.py
-venv
+
+__pycache__/
+
+# Environments
+.env
+.venv
+env/
+venv/

--- a/pipeline/util.py
+++ b/pipeline/util.py
@@ -42,8 +42,8 @@ def get_s3_buckets():
 
 
 def get_aws_machines(
-        machine_type: str='p2.xlarge',
-        location: str='us-east-1',
+        instance_type: str='p2.xlarge',
+        region: str='us-east-1',
         tag_name: str='Name',
         tag_value: str=''
     ) -> List[str]:
@@ -52,7 +52,7 @@ def get_aws_machines(
     of type machine_type.
     """
 
-    ec2 = boto3.client('ec2', region_name=location)
+    ec2 = boto3.client('ec2', region_name=region)
     response = ec2.describe_instances(
         Filters=[
             {
@@ -65,7 +65,7 @@ def get_aws_machines(
             },
             {
                 'Name': 'instance-type',
-                'Values': [machine_type]
+                'Values': [instance_type]
             }
         ]
     )

--- a/pipeline/util.py
+++ b/pipeline/util.py
@@ -13,13 +13,14 @@
 # the S3 buckets and AWS machines to use.
 #
 
-
 import os
+from platform import machine
 import subprocess
 import time
 
 import boto3
 
+from typing import List
 from pipeline.secrets import Secrets
 
 PEM_FILE = Secrets['PEM_FILE']
@@ -41,36 +42,40 @@ def get_s3_buckets():
     return buckets
 
 
-# TODO:  Add ability to look for particular tags (key,value) because might
-#  have multiple sets of machines
-def get_aws_machines(machine_type='p2.xlarge', location='us-east-1'):
-    """ Look on AWS and determine all the machines that we have running
-    AWS that we can use. The assumption is that we are looking for machines
+def get_aws_machines(
+        machine_type: str='p2.xlarge',
+        location: str='us-east-1',
+        tag_name: str='Name',
+        tag_value: str=''
+    ) -> List[str]:
+    """ Look on AWS and determine all the machines that we have running.
+    The assumption is that we are looking for machines
     of type machine_type.
     """
 
-    machines = []
-
     ec2 = boto3.client('ec2', region_name=location)
-    response = ec2.describe_instances()
-    reservations = response.get('Reservations')
-    for reservation in reservations:
-        instances = reservation.get('Instances')
-        for instance in instances:
-            instance_location = instance.get('Placement') \
-                .get('AvailabilityZone')
-            instance_type = instance.get('InstanceType')
-            public_dns = instance.get('PublicDnsName')
-            instance_status = instance.get('State').get('Code')
-
-            # Status 16 means running.
-            if instance_status == 16:
-                # Do not look for an exact match for location, because the
-                # desired location could be us-east-1, but the actual
-                # location could be 'us-east-1b'.
-                if location == "*" or instance_location.find(location) > -1:
-                    if machine_type == "*" or instance_type == machine_type:
-                        machines.append(public_dns)
+    response = ec2.describe_instances(
+        Filters=[
+            {
+                'Name': 'instance-state-name',
+                'Values': ['running']
+            },
+            {
+                'Name': f'tag:{tag_name}',
+                'Values': [f'*{tag_value}*']
+            },
+            {
+                'Name': 'instance-type',
+                'Values': [machine_type]
+            }
+        ]
+    )
+    
+    machines = [
+        instance['PublicDnsName'] 
+        for reservation in response['Reservations']
+        for instance in reservation['Instances'] 
+        ]
 
     return machines
 

--- a/pipeline/util.py
+++ b/pipeline/util.py
@@ -14,7 +14,6 @@
 #
 
 import os
-from platform import machine
 import subprocess
 import time
 


### PR DESCRIPTION
Updated utils.get_aws_machines() function to allow for EC2 instance tag search. Fixes #8 

```python
from pipeline.utils import get_aws_machines

cora_machines = get_aws_machines(tag_name="Name", tag_value="CORA")
```