### PR TITLE
MCS-729 standardizing output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ In order to test the pipeline and evaluations, the following is helpful:
 
 To run an eval, run the following command:
 ```
-aws_scripts/run_eval MODULE path/to/scene/directory [metadata_level]
+aws_scripts/run_eval MODULE path/to/scene/directory --metadata [metadata_level]
 ```
 
 There is an optional flag to disable config file validation checks if you are just running tests:
 ```
-aws_scripts/run_eval MODULE path/to/scene/directory [metadata_level] --disable_validation
+aws_scripts/run_eval MODULE path/to/scene/directory --metadata [metadata_level] --disable_validation
 ```
 
 Here is an example:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ $ source venv/bin/activate
 
 ### Run Eval Script
 
+### MCS Config File 
+
+When running an eval, there are checks to ensure that the MCS config file used is using the correct naming conventions, so that all the ingest
+and UI related functionality will work correctly (these can be turned off for testing):
+
+- **metadata** - has to be either `level1`, `level2`, or `oracle`
+- **evaluation_name** - has to be one of the following, in the exact format: `eval_3-75`, `eval_4`, `eval_5`, `eval_6`, `eval_7`, `eval_8`
+- **evaluation** - must be set to `true`
+- **team** - has to be either `mess`, `mit`, `opics`, or `baseline`
+- **s3_bucket** - should be `evaluation-images`
+- **s3_folder** - has to be the folder we store output for the current eval (right now, `eval-3.75`)
+
+If anything above changes, we will need to make sure those changes are incorporated into the ingest process/UI as needed. 
+
 #### Eval test configuration
 
 In order to test the pipeline and evaluations, the following is helpful:
@@ -42,12 +56,18 @@ In order to test the pipeline and evaluations, the following is helpful:
   * Results are only uploaded if the MCS config (configs/mcs_config_MODULE_METADATA.ini) has 'evalution=true'
   * Setting the s3_folder to have a suffix of -test is a good idea.  I.E. s3_folder=eval-35-test 
   * The S3 file names are generated partially by the 'team' and 'evaluation_name' properties.  Prefixing 'evaluation_name' with your initials or a personal ID can make it easier to find your files in S3.  I.E evaluation_name=kdrumm-eval375
+  * Make sure MCS config file validation is off if for testing (see commands below).
 
 #### Commands
 
 To run an eval, run the following command:
 ```
 aws_scripts/run_eval MODULE path/to/scene/directory [metadata_level]
+```
+
+There is an optional flag to disable config file validation checks if you are just running tests:
+```
+aws_scripts/run_eval MODULE path/to/scene/directory [metadata_level] --disable_validation
 ```
 
 Here is an example:

--- a/aws_scripts/run_eval.sh
+++ b/aws_scripts/run_eval.sh
@@ -36,8 +36,22 @@ DEFAULT_METADATA="level2"
 LOCAL_SCENE_DIR=$2
 # Removing ending slash of scene dir so we have consistency
 LOCAL_SCENE_DIR=$(echo $LOCAL_SCENE_DIR | sed 's:/*$::')
-METADATA=${3:-$DEFAULT_METADATA}
-VALIDATE_CONFIG=${4}
+METADATA=${METADATA:-$DEFAULT_METADATA}
+VALIDATE_CONFIG=''
+
+# Parse optional --parameters
+while [ $# -gt 0 ]; do
+    if [[ $1 == *"--"* ]]; then
+        if [ $1 == "--disable_validation" ] ; then
+            VALIDATE_CONFIG="$1"
+        else
+            uppercase_param=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+            param="${uppercase_param/--/}"
+            declare $param="$2"
+        fi
+   fi
+   shift
+done
 
 MCS_CONFIG=configs/mcs_config_${MODULE}_${METADATA}.ini
 

--- a/aws_scripts/run_eval.sh
+++ b/aws_scripts/run_eval.sh
@@ -37,6 +37,7 @@ LOCAL_SCENE_DIR=$2
 # Removing ending slash of scene dir so we have consistency
 LOCAL_SCENE_DIR=$(echo $LOCAL_SCENE_DIR | sed 's:/*$::')
 METADATA=${3:-$DEFAULT_METADATA}
+VALIDATE_CONFIG=${4}
 
 MCS_CONFIG=configs/mcs_config_${MODULE}_${METADATA}.ini
 
@@ -51,12 +52,13 @@ done
 # Debug info
 
 echo "Starting Ray Eval:"
-echo "  Module:        $MODULE"
-echo "  Metadata:      $METADATA"
-echo "  Scene Dir:     $LOCAL_SCENE_DIR"
-echo "  Ray Config:    $RAY_CONFIG"
-echo "  Ray Locations: $RAY_LOCATIONS_CONFIG"
-echo "  MCS config:    $MCS_CONFIG" 
+echo "  Module:             $MODULE"
+echo "  Metadata:           $METADATA"
+echo "  Scene Dir:          $LOCAL_SCENE_DIR"
+echo "  Ray Config:         $RAY_CONFIG"
+echo "  Ray Locations:      $RAY_LOCATIONS_CONFIG"
+echo "  MCS config:         $MCS_CONFIG"
+echo "  Skip Validate Flag: $VALIDATE_CONFIG"
 
 ray exec $RAY_CONFIG "mkdir -p ~/scenes/tmp/"
 
@@ -65,7 +67,11 @@ ray exec $RAY_CONFIG "mkdir -p ~/scenes/tmp/"
 ray rsync_up -v $RAY_CONFIG $LOCAL_SCENE_DIR/ '~/scenes/tmp/'
 ray rsync_up -v $RAY_CONFIG $TMP_DIR/scenes_single_scene.txt '~/scenes_single_scene.txt'
 
-ray submit $RAY_CONFIG pipeline_ray.py $RAY_LOCATIONS_CONFIG $MCS_CONFIG
+if [ "$VALIDATE_CONFIG" = '--disable_validation' ] ; then
+    ray submit $RAY_CONFIG pipeline_ray.py $RAY_LOCATIONS_CONFIG $MCS_CONFIG $VALIDATE_CONFIG
+else
+    ray submit $RAY_CONFIG pipeline_ray.py $RAY_LOCATIONS_CONFIG $MCS_CONFIG
+fi
 
 # Remove to cleanup?  or keep for debugging?
 # rm -rf $TMP_DIR

--- a/configs/mcs_config_baseline_level2.ini
+++ b/configs/mcs_config_baseline_level2.ini
@@ -12,4 +12,4 @@ s3_bucket=evaluation-images
 s3_folder=eval-35-test
 
 team=baseline
-evaluation_name=eval375
+evaluation_name=eval_3-75

--- a/configs/mcs_config_cora_level2.ini
+++ b/configs/mcs_config_cora_level2.ini
@@ -6,5 +6,5 @@ s3_bucket = evaluation-images
 s3_folder = eval-3.5
 
 team = mit
-evaluation_name = eval_3-5
+evaluation_name = eval_3-75
 

--- a/configs/mcs_config_cora_level2.ini
+++ b/configs/mcs_config_cora_level2.ini
@@ -3,7 +3,7 @@ metadata = level2
 
 evaluation = true
 s3_bucket = evaluation-images
-s3_folder = eval-3.5
+s3_folder = eval-35-test
 
 team = mit
 evaluation_name = eval_3-75

--- a/configs/mcs_config_opics_level2.ini
+++ b/configs/mcs_config_opics_level2.ini
@@ -10,4 +10,4 @@ s3_folder=eval-35-test
 ;aws_secret_access_key=
 
 team=opics
-evaluation_name=eval375
+evaluation_name=eval_3-75

--- a/configs/mcs_config_opics_oracle.ini
+++ b/configs/mcs_config_opics_oracle.ini
@@ -10,4 +10,4 @@ s3_folder=eval-35-test
 ;aws_secret_access_key=
 
 team=opics
-evaluation_name=eval375
+evaluation_name=eval_3-75

--- a/deploy_files/baseline/ray_script.sh
+++ b/deploy_files/baseline/ray_script.sh
@@ -3,7 +3,7 @@
 # Check passed mcs_config and scene file
 source /home/ubuntu/check_passed_variables.sh
 
-EVAL_DIR=/home/ubuntu/
+EVAL_DIR=/home/ubuntu
 SCENE_DIR="$EVAL_DIR/scenes/validation/"
 TMP_CFG_FILE="$EVAL_DIR/msc_cfg.ini.tmp"
 

--- a/deploy_files/mess/ray_script.sh
+++ b/deploy_files/mess/ray_script.sh
@@ -10,7 +10,7 @@ echo "Running MESS with config $mcs_configfile and scene $scene_file"
 # Start X
 # TODO: Check to see if the xserver is already running and do not restart (MCS-727)
 cd mcs-pipeline/xserver
-sudo python3 run_startx.py &
+sudo nohup python3 run_startx.py 1>startx-out.txt 2>startx-err.txt &
 sleep 20
 
 # Clear out the directories

--- a/deploy_files/mess/ray_script.sh
+++ b/deploy_files/mess/ray_script.sh
@@ -3,7 +3,7 @@
 # Check passed mcs_config and scene file
 source /home/ubuntu/check_passed_variables.sh
 
-EVAL_DIR=/home/ubuntu/mess_eval35/
+EVAL_DIR=/home/ubuntu/mess_eval35
 SCENE_DIR="$EVAL_DIR/scenes/"
 TMP_CFG_FILE="$EVAL_DIR/msc_cfg.ini.tmp"
 

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -163,7 +163,8 @@ class SceneRunner:
                 valid = False
 
             if(valid == False):
-                raise Exception('Invalid property value in MCS config file.')
+                raise Exception('Invalid property value in MCS config file. If only testing and not '
+                    'running an evaluation, please use the --disable_validation flag.')
 
     def get_scenes(self):
         """Read the scene files to use from the argument scene_list"""

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -77,14 +77,23 @@ class SceneStatus:
 class SceneRunner:
 
     scene_statuses={}
+    # Valid properties for various fields in mcs_config_file
+    METADATA_LVLS = ["level1", "level2", "oracle"]
+    EVAL_NAMES = ["eval_3-75", "eval_4", "eval_5", "eval_6", "eval_7", "eval_8"]
+    TEAM_NAMES = ["mess", "mit", "opics", "baseline"]
+    # TODO: MCS-754: Need to make the following properties more flexible for Eval 4+ and update folder structure
+    CURRENT_EVAL_BUCKET = "evaluation-images"
+    CURRENT_EVAL_FOLDER = "eval-3.75"
 
     def __init__(self, args):
 
         # Get Execution Configuration, which has scene information and how to run scripts on the worker machines
         self.exec_config = configparser.ConfigParser()
         self.exec_config.read(args.execution_config_file)
+        self.disable_validation = args.disable_validation
 
         # Get MCS configuration, which has infomation about how to run the MCS code, metadata level, etc.
+        self.check_for_valid_mcs_config(args.mcs_config_file)
         self.mcs_config = self.read_mcs_config(args.mcs_config_file)
 
         self.scene_files_list = []
@@ -126,6 +135,35 @@ class SceneRunner:
         with open(mcs_config_filename, 'r') as mcs_config_file:
             lines = mcs_config_file.readlines()
         return lines
+
+    def check_for_valid_mcs_config(self, config_file_path):
+        if(self.disable_validation == False):
+            mcs_config_parse = configparser.ConfigParser()
+            mcs_config_parse.read(config_file_path)
+
+            valid = True
+
+            if(mcs_config_parse['MCS']['evaluation'] != 'true'):
+                print('Error: Evaluation property in MCS config file is not set to true.')
+                valid = False
+            if(mcs_config_parse['MCS']['s3_bucket'] != self.CURRENT_EVAL_BUCKET):
+                print('Error: MCS Config file does not have the correct s3 bucket specified.')
+                valid = False
+            if(mcs_config_parse['MCS']['s3_folder'] != self.CURRENT_EVAL_FOLDER):
+                print('Error: MCS Config file does not have the correct s3 folder specified.')
+                valid = False
+            if(mcs_config_parse['MCS']['metadata'] not in self.METADATA_LVLS):
+                print('Error: MCS Config file does not include valid metadata level.')
+                valid = False
+            if(mcs_config_parse['MCS']['evaluation_name'] not in self.EVAL_NAMES):
+                print('Error: MCS Config file does not include valid evaluation_name.')
+                valid = False
+            if(mcs_config_parse['MCS']['team'] not in self.TEAM_NAMES):
+                print('Error: MCS Config file does not include valid team name.')
+                valid = False
+
+            if(valid == False):
+                raise Exception('Invalid property value in MCS config file.')
 
     def get_scenes(self):
         """Read the scene files to use from the argument scene_list"""
@@ -201,6 +239,12 @@ def parse_args():
     parser.add_argument(
         'mcs_config_file',
         help='Ini file that describes MCS configuration, debug, metadata, team, etc. '
+    )
+    parser.add_argument(
+        '--disable_validation',
+        default=False,
+        action='store_true',
+        help='Whether or not to skip validatation of MCS config file'
     )
     return parser.parse_args()
 


### PR DESCRIPTION
We wanted to document and enforce the correct naming of output files -- ended up going with simply validating the config file. There is an optional flag to turn off validation if we're only testing.

Also created a follow on ticket to update some of this since we're changing the s3 output folder structure in Eval 4+.