### PR TITLE
Mcs 725 logging

### DIFF
--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -234,12 +234,6 @@ class SceneRunner:
         logging.info(f"Scenes {self.scene_files_list}")
 
     def run_scenes(self):
-        # This should probably be configurable and may need to be different depending on what errors we are detecting.
-        # This should work for a first step though.
-        log_dir = pathlib.Path("/tmp/results/logs")
-        shutil.rmtree(log_dir, ignore_errors=True)
-        log_dir.mkdir(parents=True, exist_ok=True)
-
         num_retries = 3
         logging.info(f"Running {len(self.scene_files_list)} scenes")
         job_ids = []

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -249,8 +249,8 @@ class SceneRunner:
                 logging.info(f"{len(not_done)}  Result of {done_ref}:  {result}")
 
     def write_log(self, output, scene_status:SceneStatus, log_dir:pathlib.Path):
-        #Retries is +2 to get test number because +1 for next run increment and +1 for changing to 0 base to 1 base index
-        log_file = f"{pathlib.Path(scene_status.scene_file).name}-{scene_status.retries + 2}.log"
+        
+        log_file = f"{pathlib.Path(scene_status.scene_file).name}-{scene_status.retries + 1}.log"
         log_file = log_dir.joinpath(log_file)
         logging.info(f"Writing to {log_file.absolute()}")
         with open(log_file.absolute(), "a") as f:
@@ -260,7 +260,8 @@ class SceneRunner:
     def do_retry(self, not_done, scene_status:SceneStatus):
         scene_ref=scene_status.scene_file
         with open(str(scene_ref)) as scene_file:
-            job_id = run_scene.remote(self.exec_config['MCS']['run_script'],self.mcs_config, json.load(scene_file), scene_ref.name, scene_status.retries + 1)
+            #Retries is +2 to get test number because +1 for next run increment and +1 for changing to 0 base to 1 base index
+            job_id = run_scene.remote(self.exec_config['MCS']['run_script'],self.mcs_config, json.load(scene_file), scene_ref.name, scene_status.retries + 2)
             logging.info(f"Retrying {scene_ref} with job_id={job_id}")
             self.scene_statuses[job_id] = scene_status
             not_done.append(job_id)

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -22,6 +22,7 @@ from logging import config
 import ray
 import boto3
 
+# This is logging for head node during setup and distribution.  
 logging.basicConfig(level=logging.DEBUG,format="%(message)s")
 
 def push_to_s3(source_file: pathlib, bucket: str, s3_filename: str, mimetype:str='text/plain', client=None):
@@ -41,8 +42,8 @@ def push_to_s3(source_file: pathlib, bucket: str, s3_filename: str, mimetype:str
 @ray.remote(num_gpus=1)
 def run_scene(run_script, mcs_config, scene_config, scene_try):
     """ Ray """
-    scene_name=scene_config.get("name","")
-    timestamp=datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    scene_name = scene_config.get("name","")
+    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
     config = configparser.ConfigParser()
     config.read_string("\n".join(mcs_config))
 
@@ -76,11 +77,11 @@ def run_scene(run_script, mcs_config, scene_config, scene_try):
     logging.info(f"In run scene.  Running {cmd}")
 
     proc = subprocess.Popen(cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    lines=[]
+    lines = []
     for line in io.TextIOWrapper(proc.stdout, encoding="utf-8"):
         logging.info(line.rstrip())
         lines.append(line)
-    ret=proc.wait()
+    ret = proc.wait()
     output = ''.join(lines)
 
     # TODO MCS-702:  Send AWS S3 Parameters in Pipeline, Make them Ephemeral.  Until MCS-674, which will
@@ -91,7 +92,7 @@ def run_scene(run_script, mcs_config, scene_config, scene_try):
     # This seems a little dirty, but its mostly copied from MCS project.
     bucket = config.get("MCS", "s3_bucket")
     folder = config.get("MCS", "s3_folder")
-    eval_name=config.get("MCS", "evaluation_name")
+    eval_name = config.get("MCS", "evaluation_name")
     team = config.get("MCS", "team")
     metadata = config.get("MCS", "metadata")
     s3_filename = folder + "/" + '_'.join(
@@ -194,8 +195,8 @@ class SceneRunner:
         scenes_printed = []
         logging.info("Status:")
         for key in self.scene_statuses:
-            s_status=self.scene_statuses[key]
-            file=s_status.scene_file
+            s_status = self.scene_statuses[key]
+            file = s_status.scene_file
             if file not in scenes_printed:
                 scenes_printed.append(file)
                 self.print_scene_status(s_status,"  ")
@@ -262,7 +263,7 @@ class SceneRunner:
                 logging.info(f"{len(not_done)}  Result of {done_ref}:  {result}")
 
     def do_retry(self, not_done, scene_status:SceneStatus):
-        scene_ref=scene_status.scene_file
+        scene_ref = scene_status.scene_file
         with open(str(scene_ref)) as scene_file:
             #Retries is +2 to get test number because +1 for next run increment and +1 for changing to 0 base to 1 base index
             job_id = run_scene.remote(self.exec_config['MCS']['run_script'],self.mcs_config, json.load(scene_file), scene_status.retries + 2)

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -16,7 +16,6 @@ import uuid
 import subprocess
 import io
 import logging
-import shutil
 from dataclasses import dataclass, field
 from typing import List
 from logging import config

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -9,7 +9,6 @@ import argparse
 import configparser
 import datetime
 import json
-from os import mkdir
 import pathlib
 import time
 import uuid

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -89,20 +89,22 @@ def run_scene(run_script, mcs_config, scene_config, scene_try):
 
     # TODO  MCS-674:  Move Evaluation Code out of Python API (and into the pipeline)
 
-    # This seems a little dirty, but its mostly copied from MCS project.
-    bucket = config.get("MCS", "s3_bucket")
-    folder = config.get("MCS", "s3_folder")
-    eval_name = config.get("MCS", "evaluation_name")
-    team = config.get("MCS", "team")
-    metadata = config.get("MCS", "metadata")
-    s3_filename = folder + "/" + '_'.join(
-            [eval_name, metadata,
-             team,
-             scene_name, timestamp,
-             "log"]) + '.txt'
+    logs_to_s3 = config.getboolean("MCS", "logs_to_s3", fallback=True)
+    if (logs_to_s3):
+        # This seems a little dirty, but its mostly copied from MCS project.
+        bucket = config.get("MCS", "s3_bucket")
+        folder = config.get("MCS", "s3_folder")
+        eval_name = config.get("MCS", "evaluation_name")
+        team = config.get("MCS", "team")
+        metadata = config.get("MCS", "metadata")
+        s3_filename = folder + "/" + '_'.join(
+                [eval_name, metadata,
+                team,
+                scene_name, timestamp,
+                "log"]) + '.txt'
 
-    # Might need to find way to flush logs and/or stop logging.
-    push_to_s3(log_file, bucket, s3_filename)
+        # Might need to find way to flush logs and/or stop logging.
+        push_to_s3(log_file, bucket, s3_filename)
 
     logging.shutdown()
     log_file.unlink()

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -41,21 +41,20 @@ def push_to_s3(source_file: pathlib, bucket: str, s3_filename: str, mimetype:str
     )
 
 @ray.remote(num_gpus=1)
-def run_scene(run_script, mcs_config, scene_config, scene_name, scene_try):
+def run_scene(run_script, mcs_config, scene_config, scene_try):
     """ Ray """
+    scene_name=scene_config.get("name","")
     timestamp=datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
     config = configparser.ConfigParser()
     config.read_string("\n".join(mcs_config))
 
     log_dir = pathlib.Path("/tmp/results/logs")
     log_dir.mkdir(parents=True, exist_ok=True)
-    print("setup logging at "+str(log_dir))
     # Do we want the timestamp?  If so, we will leave a bunch of log files on a single machien.  
     # Do we clean up files?  If we don't do the timestamp, we will need to cleanup logs here so we 
     # don't end up with old executes logs at the top of a new execution.  This may not really happen 
     # in real evals, but happens when testing often.
     log_file = log_dir.joinpath(f"{scene_name}-{scene_try}-{timestamp}.log")
-    print("setup logging at "+str(log_file))
     setup_logging(log_file)
 
     identifier = uuid.uuid4()
@@ -92,7 +91,6 @@ def run_scene(run_script, mcs_config, scene_config, scene_name, scene_try):
     # TODO  MCS-674:  Move Evaluation Code out of Python API (and into the pipeline)
 
     # This seems a little dirty, but its mostly copied from MCS project.
-    # There is a retry number added so we save all retries and don't overwrite.
     bucket = config.get("MCS", "s3_bucket")
     folder = config.get("MCS", "s3_folder")
     eval_name=config.get("MCS", "evaluation_name")
@@ -101,11 +99,14 @@ def run_scene(run_script, mcs_config, scene_config, scene_name, scene_try):
     s3_filename = folder + "/" + '_'.join(
             [eval_name, metadata,
              team,
-             scene_name, str(scene_try),
+             scene_name, timestamp,
              "log"]) + '.txt'
 
     # Might need to find way to flush logs and/or stop logging.
     push_to_s3(log_file, bucket, s3_filename)
+
+    logging.shutdown()
+    log_file.unlink()
 
     return ret, output
 
@@ -148,7 +149,6 @@ def setup_logging(log_file):
         }
     }
     log_config["handlers"]["log-file"]["filename"]=str(log_file)
-    #logging.basicConfig(level=logging.DEBUG,format="%(message)s",hanlders=handlers)
     config.dictConfig(log_config)
 
 @dataclass
@@ -245,7 +245,7 @@ class SceneRunner:
         job_ids = []
         for scene_ref in self.scene_files_list:
             with open(str(scene_ref)) as scene_file:
-                job_id = run_scene.remote(self.exec_config['MCS']['run_script'], self.mcs_config, json.load(scene_file), scene_ref.with_suffix('').name, 1)
+                job_id = run_scene.remote(self.exec_config['MCS']['run_script'], self.mcs_config, json.load(scene_file), 1)
                 self.scene_statuses[job_id] = SceneStatus(scene_ref, 0, "pending")
                 job_ids.append(job_id)
 
@@ -259,8 +259,6 @@ class SceneRunner:
                 scene_status.run_statuses.append(run_status)
                 logging.info(f"file: {scene_status.scene_file}")
 
-                self.write_log(output, scene_status, log_dir)
-
                 self.print_run_status(run_status)
                 if (run_status.retry and scene_status.retries < num_retries):
                     self.do_retry(not_done, scene_status)
@@ -271,20 +269,11 @@ class SceneRunner:
                     scene_status.status = run_status.status
                 logging.info(f"{len(not_done)}  Result of {done_ref}:  {result}")
 
-    def write_log(self, output, scene_status:SceneStatus, log_dir:pathlib.Path):
-        
-        log_file = f"{pathlib.Path(scene_status.scene_file).name}-{scene_status.retries + 1}.log"
-        log_file = log_dir.joinpath(log_file)
-        logging.info(f"Writing to {log_file.absolute()}")
-        with open(log_file.absolute(), "a") as f:
-            f.write(output)
-        f.close()
-
     def do_retry(self, not_done, scene_status:SceneStatus):
         scene_ref=scene_status.scene_file
         with open(str(scene_ref)) as scene_file:
             #Retries is +2 to get test number because +1 for next run increment and +1 for changing to 0 base to 1 base index
-            job_id = run_scene.remote(self.exec_config['MCS']['run_script'],self.mcs_config, json.load(scene_file), scene_ref.with_suffix('').name, scene_status.retries + 2)
+            job_id = run_scene.remote(self.exec_config['MCS']['run_script'],self.mcs_config, json.load(scene_file), scene_status.retries + 2)
             logging.info(f"Retrying {scene_ref} with job_id={job_id}")
             self.scene_statuses[job_id] = scene_status
             not_done.append(job_id)


### PR DESCRIPTION
Logging updates for pipeline.  

This does not capture the head node logs.  We maybe should add that, but can do it separately.

Also note: the logs are ALWAYS pushed to S3.  Not just for evaluations.  That seems reasonable to me, but maybe not?