### PR TITLE
MCS-683 Added new ray pipeline code to generate videos.

### DIFF
--- a/autoscaler/ray_videos_aws.yaml
+++ b/autoscaler/ray_videos_aws.yaml
@@ -1,0 +1,61 @@
+#
+#   Configuration file for generating passive scene videos
+#
+# This file is a modification of: https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-full.yaml
+
+cluster_name: thomas-videos
+max_workers: 8                       # 2 is the default
+
+# Note that ray only seems to use the first availability zone, so if there are issues with that 
+# one, just need to put a different one first.
+provider:
+  type: aws
+  region: us-east-1
+  availability_zone: us-east-1a,us-east-1b,us-east-1c,us-east-1d
+  cache_stopped_nodes: True          # Default True means stopped, false means terminate.
+
+
+available_node_types:
+  ray.head.default:
+    min_workers: 0
+    max_workers: 0
+    resources: {"CPU": 4, "GPU": 1}
+    node_config:
+      InstanceType: p2.xlarge
+      ImageId: ami-0017467294d97d05c
+  ray.worker.default:
+    min_workers: 0
+    max_workers: 3
+    resources: {"CPU": 4, "GPU": 1}
+    node_config:
+      InstanceType: p2.xlarge
+      ImageId: ami-0017467294d97d05c
+      IamInstanceProfile: 
+        Arn: arn:aws:iam::795237661910:instance-profile/ray-autoscaler-worker-v1
+
+auth:
+  ssh_user: ubuntu
+
+head_node_type: ray.head.default
+
+# Copy script files to ALL nodes
+file_mounts: {
+  "/home/ubuntu/ray_script.sh": "deploy_files/videos/ray_script.sh",
+  "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
+  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh"
+}
+
+setup_commands:
+  - pip install -U ray==1.3.0
+  - chmod +x /home/ubuntu/ray_script.sh /home/ubuntu/check_passed_variables.sh /home/ubuntu/start_x_server.sh
+  - rm -rf ~/.aws/
+
+# Command to start ray on the head node. You don't need to change this.
+head_start_ray_commands:
+  - ray stop
+  - ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+
+# Command to start ray on worker nodes. You don't need to change this.
+worker_start_ray_commands:
+  - ray stop
+  - ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076

--- a/autoscaler/ray_videos_aws.yaml
+++ b/autoscaler/ray_videos_aws.yaml
@@ -3,7 +3,7 @@
 #
 # This file is a modification of: https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-full.yaml
 
-cluster_name: thomas-videos
+cluster_name: videos
 max_workers: 8                       # 2 is the default
 
 # Note that ray only seems to use the first availability zone, so if there are issues with that 

--- a/configs/mcs_config_videos_level1.ini
+++ b/configs/mcs_config_videos_level1.ini
@@ -1,0 +1,24 @@
+[MCS]
+; Always run metadata level 1 since we just need the RGB images
+metadata=level1
+; We don't need to save the scene history in order to generate the video
+history_enabled=false
+; We need to save the images in order to generate the video
+save_debug_images=true
+
+; We won't use the MCS python library to upload output to S3
+evaluation=false
+
+; Set your AWS credentials!
+aws_access_key_id=
+aws_secret_access_key=
+
+; The S3 bucket and subfolder in which to save the video file
+; Adjust either as needed, though feel free to use the existing bucket
+s3_bucket=mcs-output-videos
+s3_folder=eval-375-test
+
+; The eval and team names are used as a prefix for the video file
+; Adjust either as needed, and either (or both) can be left blank
+evaluation_name=
+team=

--- a/configs/mcs_config_videos_level1.ini
+++ b/configs/mcs_config_videos_level1.ini
@@ -9,10 +9,6 @@ save_debug_images=true
 ; We won't use the MCS python library to upload output to S3
 evaluation=false
 
-; Set your AWS credentials!
-aws_access_key_id=
-aws_secret_access_key=
-
 ; The S3 bucket and subfolder in which to save the video file
 ; Adjust either as needed, though feel free to use the existing bucket
 s3_bucket=mcs-output-videos
@@ -22,3 +18,5 @@ s3_folder=eval-375-test
 ; Adjust either as needed, and either (or both) can be left blank
 evaluation_name=
 team=
+
+; Note that AWS credentials are not needed for generating videos

--- a/configs/videos_aws.ini
+++ b/configs/videos_aws.ini
@@ -1,0 +1,11 @@
+#
+# Execution configuration for running Ray for videos on AWS
+#
+[MCS]
+run_script = /home/ubuntu/ray_script.sh
+
+
+# Location on the head node that has the scene files and what scene files to use.
+scene_location = /home/ubuntu/scenes/tmp/
+scene_list = /home/ubuntu/scenes_single_scene.txt
+

--- a/deploy_files/videos/ray_script.sh
+++ b/deploy_files/videos/ray_script.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Check passed mcs_config and scene file
+source /home/ubuntu/check_passed_variables.sh
+
+EVAL_DIR=/home/ubuntu/
+SCENE_DIR="$EVAL_DIR/scenes/validation/"
+TMP_CFG_FILE="$EVAL_DIR/msc_cfg.ini.tmp"
+
+echo "STARTING VIDEO GEN PIPELINE: CONFIG $mcs_configfile SCENE $scene_file"
+
+# Set a bad config and kill the existing X Server before starting it again.
+# Seems to be needed on non-Deep Learning AMIs. See README.
+sudo nvidia-xconfig --use-display-device=None --virtual=1280x1024 --output-xconfig=/etc/X11/xorg.conf --busid=PCI:0:31:0
+# Sleep here to ensure config file is written and X Server starts on boot
+sleep 5
+if pgrep -x Xorg > /dev/null
+then
+  echo "Killing existing X Server that started on boot"
+  sudo kill $(pgrep -x Xorg)
+  # Sleep here to ensure X Server is killed
+  sleep 5
+else
+  echo "X Server wasn't started on boot"
+fi
+
+# Start X
+source /home/ubuntu/start_x_server.sh
+
+# Clear out the directories
+echo Clearing History at $EVAL_DIR/SCENE_HISTORY/
+rm -f $EVAL_DIR/SCENE_HISTORY/*
+echo Clearing $SCENE_DIR
+rm -rf $SCENE_DIR/*
+
+# Move files to appropriate locations
+echo Making SCENE_DIR=$SCENE_DIR
+mkdir -p $SCENE_DIR
+echo Moving scene_file=$scene_file to $SCENE_DIR
+cp $scene_file $SCENE_DIR/
+
+echo "Making temporary copy of config file ($mcs_configfile -> $TMP_CFG_FILE)"
+cp $mcs_configfile $TMP_CFG_FILE
+echo Removing old config file at $EVAL_DIR/mcs_config.ini
+rm $EVAL_DIR/mcs_config.ini
+echo Moving temporary config file to config location
+mv $TMP_CFG_FILE $EVAL_DIR/mcs_config.ini
+
+# Run the Performer code
+cd $EVAL_DIR
+echo "GENERATING VIDEO: $scene_file"
+echo
+source /home/ubuntu/venv/bin/activate
+
+UNITY_APP=/home/ubuntu/unity_app/MCS-AI2-THOR-Unity-App-v0.4.3.x86_64
+
+# Read variables from MCS config file
+AWS_ACCESS_KEY_ID=$(awk -F '=' '/aws_access_key_id/ {print $2}' $mcs_configfile | xargs)
+AWS_SECRET_ACCESS_KEY=$(awk -F '=' '/aws_secret_access_key/ {print $2}' $mcs_configfile | xargs)
+S3_BUCKET=$(awk -F '=' '/s3_bucket/ {print $2}' $mcs_configfile | xargs)
+S3_FOLDER=$(awk -F '=' '/s3_folder/ {print $2}' $mcs_configfile | xargs)
+EVAL_NAME=$(awk -F '=' '/evaluation_name/ {print $2}' $mcs_configfile | xargs)
+TEAM_NAME=$(awk -F '=' '/team/ {print $2}' $mcs_configfile | xargs)
+
+# Set the output prefix by checking if EVAL_NAME or TEAM_NAME are blank
+[[ -z $EVAL_NAME || -z $TEAM_NAME ]] && OUTPUT_PREFIX=${EVAL_NAME}${TEAM_NAME} || OUTPUT_PREFIX=${EVAL_NAME}_${TEAM_NAME}
+
+# Save AWS credentials file to enable CLI calls
+AWS_FOLDER=/home/ubuntu/.aws/
+mkdir -p $AWS_FOLDER
+printf "[default]\naws_access_key_id = $AWS_ACCESS_KEY_ID\naws_secret_access_key = $AWS_SECRET_ACCESS_KEY\n" > ${AWS_FOLDER}credentials
+
+# Run the scene and create an mp4 video
+if [ -z $OUTPUT_PREFIX ]
+then
+  python3 MCS/scripts/run_last_action.py --mcs_unity_build_file $UNITY_APP --config_file $mcs_configfile --save-videos $scene_file
+else
+  python3 MCS/scripts/run_last_action.py --mcs_unity_build_file $UNITY_APP --config_file $mcs_configfile --prefix $OUTPUT_PREFIX --save-videos $scene_file
+fi
+
+# Upload the mp4 video to S3
+OUTPUT_FOLDER=/home/ubuntu/output/
+mkdir -p $OUTPUT_FOLDER
+cp ${OUTPUT_PREFIX}*.mp4 $OUTPUT_FOLDER
+aws s3 sync $OUTPUT_FOLDER s3://${S3_BUCKET}/${S3_FOLDER}/ --acl public-read
+
+# Cleanup the worker for future use
+rm ${OUTPUT_FOLDER}${OUTPUT_PREFIX}*.mp4
+rm ${AWS_FOLDER}credentials


### PR DESCRIPTION
The goal of this ticket was to create a pipeline that generates videos of passive scenes. I did this by calling the `run_last_action.sh` script that's already in the MCS GitHub repo to run a scene and generate a corresponding video (it does so without using the `evaluation` flag), and then manually uploading the video to S3.

I copied and used Clark's latest baseline versions of the files (`autoscaler/ray_baseline_aws.yaml`, `configs/baseline_aws.ini`, `configs/mcs_config_baseline_level2.ini`, `deploy_files/baseline`) except as noted. I tested using the `run_eval` script, like:

```
./aws_scripts/run_eval.sh videos <scenes_folder> --metadata level1 --disable_validation
```

Documentation on how I made the new AMI: https://github.com/NextCenturyCorporation/mcs-pipeline/pull/26