### PR TITLE
MCS-734-alsa

### DIFF
--- a/autoscaler/ray_baseline_aws.yaml
+++ b/autoscaler/ray_baseline_aws.yaml
@@ -48,11 +48,9 @@ file_mounts: {
 }
 
 setup_commands:
+  - sudo cp /home/ubuntu/asound.conf /etc/asound.conf
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
-
-worker_setup_commands:
-  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/autoscaler/ray_baseline_aws.yaml
+++ b/autoscaler/ray_baseline_aws.yaml
@@ -43,7 +43,8 @@ head_node_type: ray.head.default
 file_mounts: {
   "/home/ubuntu/ray_script.sh": "deploy_files/baseline/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
-  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh"
+  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
+  "/etc/asound.conf": "deploy_files/asound.conf"
 }
 
 setup_commands:

--- a/autoscaler/ray_baseline_aws.yaml
+++ b/autoscaler/ray_baseline_aws.yaml
@@ -44,12 +44,15 @@ file_mounts: {
   "/home/ubuntu/ray_script.sh": "deploy_files/baseline/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
   "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
-  "/etc/asound.conf": "deploy_files/asound.conf"
+  "/home/ubuntu/asound.conf": "deploy_files/asound.conf"
 }
 
 setup_commands:
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
+
+worker_setup_commands:
+  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/autoscaler/ray_cora_aws.yaml
+++ b/autoscaler/ray_cora_aws.yaml
@@ -48,7 +48,7 @@ file_mounts: {
 }
 
 setup_commands:
-  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
+  - sudo cp /home/ubuntu/asound.conf /etc/asound.conf
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
 

--- a/autoscaler/ray_cora_aws.yaml
+++ b/autoscaler/ray_cora_aws.yaml
@@ -44,12 +44,15 @@ file_mounts: {
   "/home/ubuntu/ray_script.sh": "deploy_files/cora/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
   "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
-  "/etc/asound.conf": "deploy_files/asound.conf"
+  "/home/ubuntu/asound.conf": "deploy_files/asound.conf"
 }
 
 setup_commands:
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
+
+worker_setup_commands:
+  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/autoscaler/ray_cora_aws.yaml
+++ b/autoscaler/ray_cora_aws.yaml
@@ -48,11 +48,9 @@ file_mounts: {
 }
 
 setup_commands:
+  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
-
-worker_setup_commands:
-  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/autoscaler/ray_cora_aws.yaml
+++ b/autoscaler/ray_cora_aws.yaml
@@ -43,7 +43,8 @@ head_node_type: ray.head.default
 file_mounts: {
   "/home/ubuntu/ray_script.sh": "deploy_files/cora/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
-  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh"
+  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
+  "/etc/asound.conf": "deploy_files/asound.conf"
 }
 
 setup_commands:

--- a/autoscaler/ray_mess_aws.yaml
+++ b/autoscaler/ray_mess_aws.yaml
@@ -50,11 +50,9 @@ file_mounts: {
 }
 
 setup_commands:
+  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
-
-worker_setup_commands:
-  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/autoscaler/ray_mess_aws.yaml
+++ b/autoscaler/ray_mess_aws.yaml
@@ -50,7 +50,7 @@ file_mounts: {
 }
 
 setup_commands:
-  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
+  - sudo cp /home/ubuntu/asound.conf /etc/asound.conf
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
 

--- a/autoscaler/ray_mess_aws.yaml
+++ b/autoscaler/ray_mess_aws.yaml
@@ -46,12 +46,15 @@ file_mounts: {
   "/home/ubuntu/ray_script.sh": "deploy_files/mess/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
   "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
-  "/etc/asound.conf": "deploy_files/asound.conf"
+  "/home/ubuntu/asound.conf": "deploy_files/asound.conf"
 }
 
 setup_commands:
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
+
+worker_setup_commands:
+  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/autoscaler/ray_mess_aws.yaml
+++ b/autoscaler/ray_mess_aws.yaml
@@ -45,7 +45,8 @@ head_node_type: ray.head.default
 file_mounts: {
   "/home/ubuntu/ray_script.sh": "deploy_files/mess/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
-  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh"
+  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
+  "/etc/asound.conf": "deploy_files/asound.conf"
 }
 
 setup_commands:

--- a/autoscaler/ray_opics_aws.yaml
+++ b/autoscaler/ray_opics_aws.yaml
@@ -43,7 +43,8 @@ head_node_type: ray.head.default
 file_mounts: {
   "/home/ubuntu/ray_script.sh": "deploy_files/opics/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
-  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh"
+  "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
+  "/etc/asound.conf": "deploy_files/asound.conf"
 }
 
 setup_commands:

--- a/autoscaler/ray_opics_aws.yaml
+++ b/autoscaler/ray_opics_aws.yaml
@@ -4,7 +4,7 @@
 #
 # This file is a modification of: https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-full.yaml
 
-cluster_name: opics-dw
+cluster_name: opics
 max_workers: 8                       # 2 is the default
 
 # Note that ray only seems to use the first availability zone, so if there are issues with that 

--- a/autoscaler/ray_opics_aws.yaml
+++ b/autoscaler/ray_opics_aws.yaml
@@ -4,7 +4,7 @@
 #
 # This file is a modification of: https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-full.yaml
 
-cluster_name: opics
+cluster_name: opics-dw
 max_workers: 8                       # 2 is the default
 
 # Note that ray only seems to use the first availability zone, so if there are issues with that 
@@ -48,7 +48,7 @@ file_mounts: {
 }
 
 setup_commands:
-  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
+  - sudo cp /home/ubuntu/asound.conf /etc/asound.conf
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
 

--- a/autoscaler/ray_opics_aws.yaml
+++ b/autoscaler/ray_opics_aws.yaml
@@ -48,11 +48,9 @@ file_mounts: {
 }
 
 setup_commands:
+  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
-
-worker_setup_commands:
-  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/autoscaler/ray_opics_aws.yaml
+++ b/autoscaler/ray_opics_aws.yaml
@@ -44,12 +44,15 @@ file_mounts: {
   "/home/ubuntu/ray_script.sh": "deploy_files/opics/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
   "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
-  "/etc/asound.conf": "deploy_files/asound.conf"
+  "/home/ubuntu/asound.conf": "deploy_files/asound.conf"
 }
 
 setup_commands:
   - pip install -U ray==1.3.0
   - rm -rf ~/.aws/
+
+worker_setup_commands:
+  - sudo mv /home/ubuntu/asound.conf /etc/asound.conf
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/deploy_files/asound.conf
+++ b/deploy_files/asound.conf
@@ -1,0 +1,4 @@
+pcm.!default {
+  type plug
+  slave.pcm "null"
+}


### PR DESCRIPTION
Addressing annoyances with ALSA sound card errors when running Unity runtime. Tested on baseline only.

Below is the log from a successful run without the ALSA errors.
```
2021-07-08 20:51:09,142 INFO worker.py:641 -- Connecting to existing Ray cluster at address: 172.31.20.213:6379
Starting run scenes 2021-07-08
Number of scenes: 1
Scenes [PosixPath('/home/ubuntu/scenes/tmp/juliett_0001_01.json')]
Running 1 scenes
(pid=3401) Saving mcs config information to /tmp/mcs_config.ini
(pid=3401) Saving scene information to /tmp/7e3c4931-09d3-40a3-8efb-582c7b83dd3d.json
(pid=3401) In run scene.  Running /home/ubuntu/ray_script.sh /tmp/mcs_config.ini /tmp/7e3c4931-09d3-40a3-8efb-582c7b83dd3d.json
(pid=3401) Running Baseline with config /tmp/mcs_config.ini and scene /tmp/7e3c4931-09d3-40a3-8efb-582c7b83dd3d.json
(pid=3401) X Server is running
(pid=3401) Clearing History at /home/ubuntu/SCENE_HISTORY/
(pid=3401) Clearing /home/ubuntu/scenes/validation/
(pid=3401) Making SCENE_DIR=/home/ubuntu/scenes/validation/
(pid=3401) Moving scene_file=/tmp/7e3c4931-09d3-40a3-8efb-582c7b83dd3d.json to /home/ubuntu/scenes/validation/
(pid=3401) Making temporary copy of config file (/tmp/mcs_config.ini -> /home/ubuntu/msc_cfg.ini.tmp)
(pid=3401) Removing old config file at /home/ubuntu/mcs_config.ini
(pid=3401) Moving temporary config file to config location
(pid=3401) Starting Evaluation:
(pid=3401) 
(pid=3401) Found path: /home/ubuntu/MCS-AI2-THOR-Unity-App-v0.3.8.x86_64
(pid=3401) Mono path[0] = '/home/ubuntu/MCS-AI2-THOR-Unity-App-v0.3.8_Data/Managed'
(pid=3401) Mono config path = '/home/ubuntu/MCS-AI2-THOR-Unity-App-v0.3.8_Data/Mono/etc'
(pid=3401) Preloaded 'ScreenSelector.so'
(pid=3401) Display 0 '0': 1280x1024 (primary device).
(pid=3401) Logging to /home/ubuntu/.config/unity3d/CACI with the Allen Institute for Artificial Intelligence/MCS-AI2-THOR/Player.log
(pid=3401) MCS Config File Path: ./mcs_config.ini
(pid=3401) Running scene: 7e3c4931-09d3-40a3-8efb-582c7b83dd3d.json
(pid=3401) MCS Warning: This is your last step for this scene. All your future actions will be skipped. Please call controller.end_scene() now.
(pid=3401) Pushing /tmp/results/logs/juliett_0001_01-1-20210708-205109.log to evaluation-images / eval-35-test/eval_3-75_level2_baseline_juliett_0001_01_20210708-205109_log.txt
(pid=3401) Acquiring 0
(pid=3401) UploadSubmissionTask(transfer_id=0, {'transfer_future': <s3transfer.futures.TransferFuture object at 0x7f2c680dbfd0>}) about to wait for the following futures []
(pid=3401) UploadSubmissionTask(transfer_id=0, {'transfer_future': <s3transfer.futures.TransferFuture object at 0x7f2c680dbfd0>}) done waiting for dependent futures
(pid=3401) Executing task UploadSubmissionTask(transfer_id=0, {'transfer_future': <s3transfer.futures.TransferFuture object at 0x7f2c680dbfd0>}) with kwargs {'client': <botocore.client.S3 object at 0x7f2c681cc750>, 'config': <boto3.s3.transfer.TransferConfig object at 0x7f2c680db4d0>, 'osutil': <s3transfer.utils.OSUtils object at 0x7f2c680db850>, 'request_executor': <s3transfer.futures.BoundedExecutor object at 0x7f2c680dba90>, 'transfer_future': <s3transfer.futures.TransferFuture object at 0x7f2c680dbfd0>}
(pid=3401) Submitting task PutObjectTask(transfer_id=0, {'bucket': 'evaluation-images', 'key': 'eval-35-test/eval_3-75_level2_baseline_juliett_0001_01_20210708-205109_log.txt', 'extra_args': {'ACL': 'public-read', 'ContentType': 'text/plain'}}) to executor <s3transfer.futures.BoundedExecutor object at 0x7f2c680dba90> for transfer request: 0.
(pid=3401) Acquiring 0
(pid=3401) PutObjectTask(transfer_id=0, {'bucket': 'evaluation-images', 'key': 'eval-35-test/eval_3-75_level2_baseline_juliett_0001_01_20210708-205109_log.txt', 'extra_args': {'ACL': 'public-read', 'ContentType': 'text/plain'}}) about to wait for the following futures []
(pid=3401) Releasing acquire 0/None
(pid=3401) PutObjectTask(transfer_id=0, {'bucket': 'evaluation-images', 'key': 'eval-35-test/eval_3-75_level2_baseline_juliett_0001_01_20210708-205109_log.txt', 'extra_args': {'ACL': 'public-read', 'ContentType': 'text/plain'}}) done waiting for dependent futures
(pid=3401) Executing task PutObjectTask(transfer_id=0, {'bucket': 'evaluation-images', 'key': 'eval-35-test/eval_3-75_level2_baseline_juliett_0001_01_20210708-205109_log.txt', 'extra_args': {'ACL': 'public-read', 'ContentType': 'text/plain'}}) with kwargs {'client': <botocore.client.S3 object at 0x7f2c681cc750>, 'fileobj': <s3transfer.utils.ReadFileChunk object at 0x7f2c680eb310>, 'bucket': 'evaluation-images', 'key': 'eval-35-test/eval_3-75_level2_baseline_juliett_0001_01_20210708-205109_log.txt', 'extra_args': {'ACL': 'public-read', 'ContentType': 'text/plain'}}
file: /home/ubuntu/scenes/tmp/juliett_0001_01.json
Code: 0
Status: Success
Retryable: False
0  Result of ObjectRef(a67dc375e60ddd1affffffffffffffffffffffff0100000001000000):  0
Status:
  Scene: Success - /home/ubuntu/scenes/tmp/juliett_0001_01.json
    retries: 0
    Attempt 0
      Code: 0
      Status: Success
      Retryable: False
Finished run scenes 2021-07-08
(pid=3401) Releasing acquire 0/None

*********************************
Finished.  Hit enter to finish
```