### PR TITLE
grouping commands in script such that redirections apply to all

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,20 @@ There is an optional flag to disable config file validation checks if you are ju
 aws_scripts/run_eval MODULE path/to/scene/directory --metadata [metadata_level] --disable_validation
 ```
 
-Here is an example:
+To capture the output in a log file, add the following after the command.  Tee will allow the output to be sent both to stdout as well as the file.  
+
+```
+|& tee <log_filename>
+```
+
+You can also use linux pipes to only push to a file.
+
+Here are examples:
 ```
 ./aws_scripts/run_eval.sh baseline scenes/subset/
+
+
+./aws_scripts/run_eval.sh baseline scenes/subset/ |& tee out.txt
 ```
 
 Note: This script does not stop your cluster.  You should be sure to stop your cluster (See Common Ray Commands) or carefully terminate your AWS instances associated with the cluster.

--- a/aws_scripts/run_eval.sh
+++ b/aws_scripts/run_eval.sh
@@ -5,7 +5,7 @@
 #  2. Upload the appropriate scenes
 #  3. Upload the config files
 #  4. Start the eval
-
+{
 MODULE=$1
 TMP_DIR=.tmp_pipeline_ray
 
@@ -89,3 +89,4 @@ fi
 
 # Remove to cleanup?  or keep for debugging?
 # rm -rf $TMP_DIR
+} 


### PR DESCRIPTION
If you add a redirect to the script previously, not all of the output went to the file or stdout.  In order to send all output to files, we needed the script to have a unit of I/O redirection.  The curly braces create this unit around the entire script.

Adding any redirection to the script command should redirect all the output in the script.  I like using tee by adding `|& tee output.file.txt`

See https://stackoverflow.com/questions/314675/how-to-redirect-output-of-an-entire-shell-script-within-the-script-itself