### PR TITLE
MCS-711 - Ability to run pipeline on local machine as opposed to a remote cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,13 @@ Retryable: False
 
 ## Run Pipeline Locally
 
-TBD
+To run the pipeline locally, make sure to update the paths in configs/test_local.ini and the EVAL_DIR in deploy_files/local/ray_script.sh to match your local machine. Then run the following:
+
+```
+python pipeline_ray.py configs/test_local.ini configs/mcs_config_local_level2.ini --disable_validation --local_only
+```
+
+The ray_script.sh here is set to run run_just_pass.py from the MCS project on the list of scenes passed along, but that can be changed to whatever is needed.
 
 ## Project Structure
 

--- a/configs/mcs_config_local_level2.ini
+++ b/configs/mcs_config_local_level2.ini
@@ -1,0 +1,11 @@
+[MCS]
+metadata=level2
+
+evaluation=false
+;s3_bucket=evaluation-images
+;s3_folder=eval-35-test
+history_enabled=false
+
+team=mcs
+evaluation_name=local_test
+logs_to_s3=false

--- a/configs/test_local.ini
+++ b/configs/test_local.ini
@@ -1,0 +1,13 @@
+#
+# Template example for running Ray locally
+#
+[MCS]
+# path on local machine ('some/local/path/mcs-pipeline/' should be wherever
+# you have the pipeline project checked out)
+run_script = some/local/path/mcs-pipeline/deploy_files/local/ray_script.sh
+
+# Location on the local machine that has the scene files.  The scenes to actually use
+# are listed in the scenes_single_scene.txt file or the scenes_juliett.txt, or something
+# similar
+scene_location = path/to/scenes
+scene_list = path/to/list/somelist.txt

--- a/deploy_files/local/ray_script.sh
+++ b/deploy_files/local/ray_script.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Check passed mcs_config and scene file
+LOCAL_DIR=$(dirname $0)
+CHECK_PASSED_VAR_LOC="${LOCAL_DIR%/*}/check_passed_variables.sh"
+
+source $CHECK_PASSED_VAR_LOC
+
+# Your local directory - for this example, its where ever you have your 
+# MCS python API package checked out
+EVAL_DIR=some/local/path/mcs-python
+SCENE_DIR="$EVAL_DIR/tmp_scenes/"
+TMP_CFG_FILE="$EVAL_DIR/msc_cfg.ini.tmp"
+
+echo "Running local test with config $mcs_configfile and scene $scene_file"
+
+echo "Making temporary copy of config file ($mcs_configfile -> $TMP_CFG_FILE)"
+cp $mcs_configfile $TMP_CFG_FILE
+echo Removing old config file at $EVAL_DIR/mcs_config_local.ini
+rm $EVAL_DIR/mcs_config_local.ini
+echo Moving temporary config file to config location
+mv $TMP_CFG_FILE $EVAL_DIR/mcs_config_local.ini
+
+# Run a test script
+cd $EVAL_DIR
+echo Starting Evaluation:
+source venv/bin/activate
+python scripts/run_just_pass.py $scene_file --config_file $EVAL_DIR/mcs_config_local.ini 

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -246,8 +246,8 @@ class SceneRunner:
 
         self.scene_files_list = []
 
-        # Scene_statuses keeps track of all the scenes and current status.
-        # Maps job_id to SceneStatus object
+        # Scene_statuses keeps track of all the scenes and their current
+        # status. Maps job_id to SceneStatus object
         self.scene_statuses = {}
 
         # List of all the job references that have been submitted to Ray that
@@ -490,6 +490,14 @@ def parse_args():
         action='store_true',
         help='Whether to attempt to resume last run.'
     )
+    parser.add_argument(
+        '--local_only',
+        default=False,
+        action='store_true',
+        help='Whether or not one is running on a local machine ' +
+             'or on a remote cluster'
+    )
+
     return parser.parse_args()
 
 
@@ -511,11 +519,12 @@ if __name__ == '__main__':
 
     start_time = show_datetime_string("Start time: ")
 
-    # TODO MCS-711:  If running local, do ray.init().  If doing remote/cluster,
-    #  do (address='auto').  Add command line switch or configuration to
-    #  determine which to use
-    ray.init(address='auto')
-    # ray.init()
+    # Note that logging_level is set to logging.INFO by default
+    # in ray.init() call (in case we need to change logging levels)
+    if(args.local_only):
+        ray.init(local_mode=True)
+    else:
+        ray.init(address='auto')
 
     try:
         scene_runner = SceneRunner(args)

--- a/pipeline_ray.py
+++ b/pipeline_ray.py
@@ -246,8 +246,8 @@ class SceneRunner:
 
         self.scene_files_list = []
 
-        # Scene_statuses keeps track of all the scenes and their current
-        # status. Maps job_id to SceneStatus object
+        # Scene_statuses keeps track of all the scenes and current status.
+        # Maps job_id to SceneStatus object
         self.scene_statuses = {}
 
         # List of all the job references that have been submitted to Ray that


### PR DESCRIPTION
For some reason I wrote MCS-712 on my commit (oops).

Can run the pipeline_ray.py file on your local machine. The README has what files to edit to point to the appropriate paths on your local machine as well as the command. 