### PR TITLE
Remove max_workers line from ray.worker.default (part of MCS-763).

### DIFF
--- a/autoscaler/ray_baseline_aws.yaml
+++ b/autoscaler/ray_baseline_aws.yaml
@@ -26,7 +26,6 @@ available_node_types:
       ImageId: ami-0e230ba090bb7ad02
   ray.worker.default:
     min_workers: 0
-    max_workers: 3
     resources: {"CPU": 4, "GPU": 1}
     node_config:
       InstanceType: p2.xlarge

--- a/autoscaler/ray_cora_aws.yaml
+++ b/autoscaler/ray_cora_aws.yaml
@@ -26,7 +26,6 @@ available_node_types:
       ImageId: ami-00da8aa4b07be3e9a
   ray.worker.default:
     min_workers: 0
-    max_workers: 2
     resources: {"CPU": 4, "GPU": 1}
     node_config:
       InstanceType: p2.xlarge

--- a/autoscaler/ray_mess_aws.yaml
+++ b/autoscaler/ray_mess_aws.yaml
@@ -28,7 +28,6 @@ available_node_types:
       ImageId: ami-01cdf3366349ef0b2 # AMI 'mess-3.5-ray-v7' originally built from 'mess-35-beta'
   ray.worker.default:
     min_workers: 0
-    max_workers: 3
     resources: {"CPU": 4, "GPU": 1}
     node_config:
       InstanceType: p2.xlarge

--- a/autoscaler/ray_opics_aws.yaml
+++ b/autoscaler/ray_opics_aws.yaml
@@ -26,7 +26,6 @@ available_node_types:
       ImageId: ami-08b3c4d663c483fd0
   ray.worker.default:
     min_workers: 0
-    max_workers: 2
     resources: {"CPU": 4, "GPU": 1}
     node_config:
       InstanceType: p2.xlarge

--- a/autoscaler/ray_videos_aws.yaml
+++ b/autoscaler/ray_videos_aws.yaml
@@ -25,7 +25,6 @@ available_node_types:
       ImageId: ami-0017467294d97d05c
   ray.worker.default:
     min_workers: 0
-    max_workers: 3
     resources: {"CPU": 4, "GPU": 1}
     node_config:
       InstanceType: p2.xlarge


### PR DESCRIPTION
"Getting more perfect humans" as stated in the ticket would still be nice, but now we should only have to update max_workers in one place (top of the file) instead of two. 