### PR TITLE
Added some fixes for library updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Config File API (yaml):
 #### Commands
 
 This script assumes you have the ts.  you can install ts via `sudo apt install moreutils`
+This script assumes you have the unbuffer.  you can install ts via `sudo apt install expect`
 
 Python Script:
 

--- a/mako/templates/ray_template_aws.yaml
+++ b/mako/templates/ray_template_aws.yaml
@@ -52,10 +52,11 @@ file_mounts: {
 setup_commands:
   - sudo cp /home/ubuntu/asound.conf /etc/asound.conf
   - pip install --upgrade pip
-  - pip install -U "ray[default]"==1.3.0
-  - pip install aioredis==1.3.1
-  - pip install aiohttp==3.7.4.post0 # Is this ok for all performers?
-  - rm -rf ~/.aws/
+#  - aws configure set region us-east-1
+  - pip install -U "ray[default]"==1.13.0
+#  - pip install aioredis==1.3.1
+#  - pip install aiohttp==3.7.4.post0 # Is this ok for all performers?
+#  - rm -rf ~/.aws/
   ${additional_setup_commands}
 
 # Command to start ray on the head node. You don't need to change this.

--- a/mako/templates/ray_template_aws.yaml
+++ b/mako/templates/ray_template_aws.yaml
@@ -52,7 +52,6 @@ file_mounts: {
 setup_commands:
   - sudo cp /home/ubuntu/asound.conf /etc/asound.conf
   - pip install --upgrade pip
-#  - aws configure set region us-east-1
   - pip install -U "ray[default]"==1.13.0
 #  - pip install aioredis==1.3.1
 #  - pip install aiohttp==3.7.4.post0 # Is this ok for all performers?

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 boto3==1.17.24
 flake8==3.8.4
-ray[default]==1.3.0
-aioredis==1.3.1
+ray[default]==1.13.0
 Mako==1.1.6
 configparser==5.1.0
 pre-commit==2.16.0

--- a/run_eval_single.py
+++ b/run_eval_single.py
@@ -15,6 +15,12 @@ def parse_args():
         help="Local scene directory to be used for a single run.",
     )
     parser.add_argument(
+        "--local_template_dir",
+        "-b",
+        default="mako",
+        help="Local directory containing 'variables' and 'templates' directory for creating config files.",
+    )
+    parser.add_argument(
         "--dev_validation",
         "-d",
         default=False,


### PR DESCRIPTION
The pipeline was broken when Jacob and I tried to test it with opics.  The main fix was to just using the latest version of ray 1 (1.13).  This change should be noted and kept in mind for all performers.

Note: The old version seemed to work for Thomas with videos, so I'm not sure why it didn't work for OPICS.