### PR TITLE
MCS-1347 - MESS g4dn changes

### DIFF
--- a/configs/mess_aws.ini
+++ b/configs/mess_aws.ini
@@ -6,4 +6,4 @@ run_script = /home/ubuntu/ray_script.sh
 
 scene_location = /home/ubuntu/scenes/tmp/
 scene_list = /home/ubuntu/scenes_single_scene.txt
-eval_dir = /home/ubuntu/mess_eval4
+eval_dir = /home/ubuntu/mess_eval5

--- a/deploy_files/mess/ray_script.sh
+++ b/deploy_files/mess/ray_script.sh
@@ -31,7 +31,12 @@ cd "$eval_dir" || exit
 
 # Activate conda environment
 source /home/ubuntu/anaconda3/etc/profile.d/conda.sh
-conda activate af_mess4
+conda activate mess5
+
+# if DISPLAY environment variable is set in their environment,
+# unset it - they are setup a little differently and use vncserver
+# instead
+unset DISPLAY
 
 # Run the Performer code
 echo Starting Evaluation:
@@ -49,6 +54,6 @@ scene_file_basename=$(basename "$scene_file")
 # run with SUBMISSION_ID set to '1' or '2' for both MESS submissions
 #python3 script_mess.py scenes/$scene_file_basename $SUBMISSION_ID
 
-python script_mess_eval4_ms.py scenes/"$scene_file_basename"
+python src/script_mess_clean.py scenes/"$scene_file_basename"
 
 unset MCS_CONFIG_FILE_PATH

--- a/deploy_files/start_x_server.sh
+++ b/deploy_files/start_x_server.sh
@@ -6,7 +6,14 @@ then
   echo 'X Server is running'
 else
   echo "Starting X Server"
-  sudo nvidia-xconfig --use-display-device=None --virtual=1280x1024 --output-xconfig=/etc/X11/xorg.conf --busid=PCI:0:30:0
+  # Note that switching from the p2.xlarge machines to g4dn.xlarge means using a Tesla T4 card,
+  # instead of a K80. This is important because T4 doesn't support the --use-display-device=None
+  # option that used to be specified here.
+
+  # See "No Scanout Mode" here:
+  # https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-440-3301/index.html#known-issues
+
+  sudo nvidia-xconfig --virtual=1280x1024 --output-xconfig=/etc/X11/xorg.conf --busid=PCI:0:30:0
   sudo /usr/bin/Xorg :0 1>startx-out.txt 2>startx-err.txt &
   echo "Sleeping for 20 seconds to wait for X server"
   sleep 20

--- a/deploy_files/start_x_server.sh
+++ b/deploy_files/start_x_server.sh
@@ -13,7 +13,7 @@ else
   # See "No Scanout Mode" here:
   # https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-440-3301/index.html#known-issues
 
-  sudo nvidia-xconfig --virtual=1280x1024 --output-xconfig=/etc/X11/xorg.conf --busid=PCI:0:30:0
+  sudo nvidia-xconfig --no-use-display-device --virtual=1280x1024 --output-xconfig=/etc/X11/xorg.conf --busid=PCI:0:30:0
   sudo /usr/bin/Xorg :0 1>startx-out.txt 2>startx-err.txt &
   echo "Sleeping for 20 seconds to wait for X server"
   sleep 20

--- a/mako/templates/mcs_config_template.ini
+++ b/mako/templates/mcs_config_template.ini
@@ -11,7 +11,7 @@ video_enabled=${video_enabled}
 history_enabled=${history_enabled}
 save_debug_images=${save_debug_images}
 
-team=${team}
+team=mess-g4dn
 evaluation_name=${eval_name}
 logs_to_s3=true
 

--- a/mako/templates/ray_template_aws.yaml
+++ b/mako/templates/ray_template_aws.yaml
@@ -22,15 +22,15 @@ available_node_types:
   ray.head.default:
     min_workers: 0
     max_workers: 0
-    resources: {"CPU": 4, "GPU": 1}
+    resources: ${resources}
     node_config:
-      InstanceType: p2.xlarge
+      InstanceType: ${InstanceType}
       ImageId: ${ami}
   ray.worker.default:
     min_workers: 0
-    resources: {"CPU": 4, "GPU": 1}
+    resources: ${resources}
     node_config:
-      InstanceType: p2.xlarge
+      InstanceType: ${InstanceType}
       ImageId: ${ami}
       IamInstanceProfile:
         Arn: arn:aws:iam::795237661910:instance-profile/ray-autoscaler-worker-v1

--- a/mako/variables/default.yaml
+++ b/mako/variables/default.yaml
@@ -6,6 +6,8 @@ idle_timeout_minutes: 5
 additional_setup_commands: ""
 additional_file_mounts: ""
 cache_stopped_nodes: True
+resources: {"CPU": 4, "GPU": 1}
+InstanceType: p2.xlarge
 
 #Below is for mcs_config_template.ini
 mcs_config_extra: ""

--- a/mako/variables/mess.yaml
+++ b/mako/variables/mess.yaml
@@ -3,6 +3,7 @@ team: "mess"
 region: us-east-1
 ami: ami-0f3d2fc73250f2b55 # AMI 'MESS-5-g4dn-v1'
 InstanceType: g4dn.xlarge
+resources: {"CPU": 4, "GPU": 1}
 
 #ami: ami-00ad4212c970adc83 # AMI 'MESS-5-v1'
 idle_timeout_minutes: 10

--- a/mako/variables/mess.yaml
+++ b/mako/variables/mess.yaml
@@ -1,4 +1,6 @@
-ami: ami-0692e3996c2cd196e # AMI 'MESS-4-v7'
-idle_timeout_minutes: 10
 cluster: "mess"
 team: "mess"
+workers: 4
+region: us-east-1
+ami: ami-00ad4212c970adc83 # AMI 'MESS-5-v1'
+idle_timeout_minutes: 10

--- a/mako/variables/mess.yaml
+++ b/mako/variables/mess.yaml
@@ -1,6 +1,8 @@
 cluster: "mess"
 team: "mess"
-workers: 4
 region: us-east-1
-ami: ami-00ad4212c970adc83 # AMI 'MESS-5-v1'
+ami: ami-0f3d2fc73250f2b55 # AMI 'MESS-5-g4dn-v1'
+InstanceType: g4dn.xlarge
+
+#ami: ami-00ad4212c970adc83 # AMI 'MESS-5-v1'
 idle_timeout_minutes: 10


### PR DESCRIPTION
Changes to get g4dn.xlarge machines working -- main things:
- deploy_files/start_x_server.sh changes since the graphics card is a bit different (just removing `--use-display-device=None` and adding `--no-use-display-device`)
- *.yaml template file updates so that we can use slightly different machine types/resources if needed

~~In addition, you will likely need to comment out the `"UseDisplayDevice" "None"` option out of the /etc/X11/xorg.conf file (I did this and re-snapshotted, but we could also commit an xorg.conf + copy it up on initialization, unless there's something I'm missing).~~ No longer needed with Brian's update/`--no-use-display-device` flag.

May be taken care of depending on how you do the previous step, but **COPY YOUR AMI FIRST.** I tried setting some of this up again against one of my p2xlarge snapshots and got a warning about deleting my existing volume.
