### PR TITLE
MCS-1427 Updating Outdated Sections of Pipeline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ To run the pipeline locally, make sure to update the paths in configs/test_local
 - "scene_list" is a .txt file that you put one scene on each line to run.
 - "eval_dir" is where the evaluations are written
 
-If you'd like to test upload to S3 from a local machine, also ensure that you have your credentials and config setup correctly in ~/.aws (directions [here] (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)) and update the config in mako/templates/mcs_config_template.ini.
+If you'd like to test upload to S3 from a local machine, also ensure that you have your credentials and config setup correctly in ~/.aws (directions [here] (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)) and update the config in configs/mcs_config_local_level2.ini.
 
 Then run the following:
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ In order to test the pipeline and evaluations, the following is helpful:
   * Results are only uploaded if `evalution_bool: true`
   * Setting the s3_folder in the MCS config file to have a suffix of -test is a good idea.  I.E. `s3_folder: eval-35-test`
   * The S3 file names are generated partially by the `team` and `evaluation_name` properties in the MCS config file.  Prefixing `evaluation_name` with your initials or a personal ID can make it easier to find your files in S3.  I.E eval_name: kdrumm-eval375
-  * If you'd like to disable logs being uploaded to s3 while testing, change `logs_to_s3` to be `false` in `mako/templates/mcs_config_template.ini` (if running remotely) or `configs/mcs_config_local_level2` (if running locally)
+  * If you'd like to disable logs being uploaded to s3 while testing, change `logs_to_s3` to be `false` in `mako/templates/mcs_config_template.ini`
   * Make sure MCS config file validation is off if for testing (see commands below).
 
 #### Eval orchestration script

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Configuration files and a resume.yaml will be written in the .tmp_pipeline_ray d
 
 #### Log Parsing
 
+TODO
+
 If run_eval.sh is run with 'ts -s', the output logs can be parsed by the pipeline/log_parser.py.  This command will split the logs into logs per working node and then use some regex to report some metrics on how long different portions of a run took.  At the moment, the script output is somewhat rough and it only has good support for tracking opics logging.
 
 #### Script Overview
@@ -219,7 +221,7 @@ Retryable: False
 * Copy files to head node: `ray rsync_up /path/to/config.yaml SOURCE DEST`
 * Execute shell command on head node: `ray exec /path/to/config.yaml "COMMAND"`
 * Submit a Ray python script to the cluster: `ray submit /path/to/config.yaml PARAMETER1 PARAMETER2`
-* Monitor cluster (creates tunnel so you can see it locally): `ray dashboard autoscaler/ray_baseline_aws.yaml`
+* TODO Monitor cluster (creates tunnel so you can see it locally): `ray dashboard autoscaler/ray_baseline_aws.yaml`
   * Point browser to localhost:8265 (port will be in command output)
 * Connect to shell on head node: `ray attach /path/to/config.yaml`
 * Shutdown cluster (stops AWS instances): `ray down /path/to/config.yaml`
@@ -292,6 +294,8 @@ This will allow the EC2 machines to be called without you agreeing to accept the
 manually.
 
 ### Logs
+
+TODO
 
 Logs will be written to the head node and sometimes be pushed to S3.  Details TBD.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ In order to test the pipeline and evaluations, the following is helpful:
   * Results are only uploaded if `evalution_bool: true`
   * Setting the s3_folder in the MCS config file to have a suffix of -test is a good idea.  I.E. `s3_folder: eval-35-test`
   * The S3 file names are generated partially by the `team` and `evaluation_name` properties in the MCS config file.  Prefixing `evaluation_name` with your initials or a personal ID can make it easier to find your files in S3.  I.E eval_name: kdrumm-eval375
-  * If you'd like to disable logs being uploaded to s3 while testing, change `logs_to_s3` in `mako/templates/mcs_config_template.ini` to be `false`
+  * If you'd like to disable logs being uploaded to s3 while testing, change `logs_to_s3` to be `false` in `mako/templates/mcs_config_template.ini` (if running remotely) or `configs/mcs_config_local_level2` (if running locally)
   * Make sure MCS config file validation is off if for testing (see commands below).
 
 #### Eval orchestration script
@@ -228,14 +228,12 @@ Retryable: False
 
 To run the pipeline locally, make sure to update the paths in configs/test_local.ini to match your local machine.
 
-- "run_script" is currently mcs-pipeline/deploy_files/local/ray_script.sh
-- "scene_location" is currently MCS/docs/source/scenes/
+- "run_script" will be `<mcs-pipeline>/deploy_files/local/ray_script.sh`
+- "scene_location" is where the JSON scene files are located; you can find some sample scenes in the `docs/source/scenes/` folder in the `MCS` GitHub repository
 - "scene_list" is a .txt file that you put one scene on each line to run.
 - "eval_dir" is where the evaluations are written
 
 If you'd like to test upload to S3 from a local machine, also ensure that you have your credentials and config setup correctly in ~/.aws (directions [here] (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)) and update the config in mako/templates/mcs_config_template.ini.
-
-Next you will need to create a "local.yaml" in the "autoscaler" directory. Examples can be found at https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-full.yaml
 
 Then run the following:
 
@@ -282,12 +280,6 @@ EC2 machines.
 * Add the following to your ~/.ssh/config:   <code>StrictHostKeyChecking accept-new</code>
 This will allow the EC2 machines to be called without you agreeing to accept them
 manually.
-
-### Logs
-
-TODO
-
-Logs will be written to the head node and sometimes be pushed to S3.  Details TBD.
 
 ### Mess Example
 

--- a/configs/mcs_config_local_level2.ini
+++ b/configs/mcs_config_local_level2.ini
@@ -2,7 +2,7 @@
 metadata=level2
 
 evaluation=false
-;s3_bucket=evaluation-images
+;s3_bucket=dev-evaluation-images
 ;s3_folder=eval-35-test
 video_enabled=true
 history_enabled=true

--- a/configs/mcs_config_local_level2.ini
+++ b/configs/mcs_config_local_level2.ini
@@ -1,0 +1,12 @@
+[MCS]
+metadata=level2
+
+evaluation=false
+;s3_bucket=evaluation-images
+;s3_folder=eval-35-test
+video_enabled=true
+history_enabled=true
+
+team=mcs
+evaluation_name=local_test
+logs_to_s3=false

--- a/deploy_files/local/ray_script.sh
+++ b/deploy_files/local/ray_script.sh
@@ -20,6 +20,6 @@ cd "$eval_dir" || exit
 echo Starting Evaluation:
 # shellcheck source=/dev/null
 source venv/bin/activate
-python machine_common_sense/scripts/run_just_pass.py "$scene_file" --config_file "$eval_dir"/mcs_config_local.ini
+python machine_common_sense/scripts/run_just_pass.py "$scene_file"
 
 unset MCS_CONFIG_FILE_PATH

--- a/pipeline/log_parser.py
+++ b/pipeline/log_parser.py
@@ -17,7 +17,7 @@ import shutil
 from typing import List
 
 IP_REGEX = "ip=(\\d+\\.\\d+\\.\\d+\\.\\d+)"
-PID_REGEX = "\\(pid=(\\d+)"
+PID_REGEX = "\\(run_scene pid=(\\d+)"
 TIMESTAMP_REGEX = "^(\\d{2}:\\d{2}:\\d{2})"
 
 


### PR DESCRIPTION
Some sections of the pipeline README were significantly outdated and still referenced files/folders from before the mako refactoring (like "autoscaler" and "aws_scripts"). I've made some changes that I believe are correct (though please double-check my work), and I'll note other areas in the comments that I know still need to be updated.