### PR TITLE
MCS-1481 - Fix issue with non-existent directory in run_eval_single 

### DIFF
--- a/run_eval_single.py
+++ b/run_eval_single.py
@@ -1,4 +1,5 @@
 import argparse
+import pathlib
 
 from run_eval import EvalParams, EvalRun, execute_shell, get_now_str
 
@@ -72,7 +73,10 @@ if __name__ == "__main__":
     team = args.team
     override = {"team": team} if team else {}
     log_team = f"{team}-" if team else ""
-    log_file = f"logs/{now}-{log_team}{vars}-{args.metadata}.log"
+    log_dir_path = "logs-single-run"
+    log_dir = pathlib.Path(log_dir_path)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = f"{log_dir_path}/{now}-{log_team}{vars}-{args.metadata}.log"
     ep = EvalParams(
         args.varset, args.local_scene_dir, args.metadata, override=override
     )


### PR DESCRIPTION
Should address error being thrown if that logs directory doesn't exist. Also changed the name of the directory for clarity. 
