### PR TITLE
Use non-standard team names like opics-v2

### DIFF
--- a/mako/templates/ray_template_aws.yaml
+++ b/mako/templates/ray_template_aws.yaml
@@ -42,7 +42,7 @@ head_node_type: ray.head.default
 
 # Copy script files to ALL nodes
 file_mounts: {
-  "/home/ubuntu/ray_script.sh": "deploy_files/${team}/ray_script.sh",
+  "/home/ubuntu/ray_script.sh": "deploy_files/${filePrefix}/ray_script.sh",
   "/home/ubuntu/check_passed_variables.sh": "deploy_files/check_passed_variables.sh",
   "/home/ubuntu/start_x_server.sh": "deploy_files/start_x_server.sh",
   "/home/ubuntu/asound.conf": "deploy_files/asound.conf",

--- a/run_eval.py
+++ b/run_eval.py
@@ -299,6 +299,7 @@ class EvalRun:
     metadata = "level2"
     local_scene_dir = None
     set_status_holder = None
+    file_prefix = None
 
     def __init__(
         self,
@@ -341,17 +342,20 @@ class EvalRun:
         now = get_now_str()
         team = vars.get("team", "none")
         self.team = team
-        file_prefix = vars.get("filePrefix", team)
+        # Fall back on the team name
+        self.file_prefix = vars.get("filePrefix", team)
+        # Update the filePrefix in the vars for the ray config template
+        vars["filePrefix"] = self.file_prefix
 
         suffix = f"-{cluster}" if cluster else ""
-        working_name = f"{now}-{file_prefix}{suffix}"
+        working_name = f"{now}-{self.file_prefix}{suffix}"
         group_working_dir.mkdir(exist_ok=True, parents=True)
         working = group_working_dir / working_name
         working.mkdir()
         self.scene_list_file = working / SCENE_LIST_FILENAME
         self.working_dir = working
 
-        self.ray_locations_config = f"configs/{file_prefix}_aws.ini"
+        self.ray_locations_config = f"configs/{self.file_prefix}_aws.ini"
 
         # Generate Ray Config
         ray_cfg_template = Template(
@@ -359,7 +363,7 @@ class EvalRun:
         )
 
         ray_cfg = ray_cfg_template.render(**vars)
-        ray_cfg_file = working / f"ray_{file_prefix}_aws.yaml"
+        ray_cfg_file = working / f"ray_{self.file_prefix}_aws.yaml"
         ray_cfg_file.write_text(ray_cfg)
         self.ray_cfg_file = ray_cfg_file
 
@@ -368,7 +372,9 @@ class EvalRun:
             filename=f"{base_dir}/templates/mcs_config_template.ini"
         )
         mcs_cfg = mcs_cfg_template.render(**vars)
-        mcs_cfg_file = working / f"mcs_config_{file_prefix}_{self.metadata}.ini"
+        mcs_cfg_file = (
+            working / f"mcs_config_{self.file_prefix}_{self.metadata}.ini"
+        )
         mcs_cfg_file.write_text(mcs_cfg)
         self.mcs_cfg_file = mcs_cfg_file
 
@@ -449,8 +455,14 @@ class EvalRun:
             # metadata level
             ray.up()
 
+            # Try using the team name to find the deploy files.
+            deploy_files = f"deploy_files/{self.team}/"
+            if not os.path.exists(deploy_files):
+                # If that doesn't work, try using the file prefix instead.
+                deploy_files = f"deploy_files/{self.file_prefix}/"
+
             ray.rsync_up("pipeline", "~")
-            ray.rsync_up(f"deploy_files/{self.team}/", "~")
+            ray.rsync_up(deploy_files, "~")
             ray.rsync_up("configs/", "~/configs/")
             ray.rsync_up(self.mcs_cfg_file.as_posix(), "~/configs/")
 


### PR DESCRIPTION
In `mako/variables/<team>.yaml`, if you want to change the `team` name to something different like `opics-v2`, you can now add the `filePrefix` setting (in the same file) using the original team name (like `filePrefix: opics`), which will use the proper files in the `configs` and `deploy_files` folders. (The "filePrefix" already existed, and worked for the `configs` folder, but not the `deploy_files`, thus this PR.)