### PR TITLE
Added a fallback for the timestamp in our log files.

### DIFF
--- a/ray_scripts/pipeline_ray.py
+++ b/ray_scripts/pipeline_ray.py
@@ -206,8 +206,10 @@ def run_scene(
 
     logs_to_s3 = mcs_config.getboolean("MCS", "logs_to_s3", fallback=True)
     if logs_to_s3:
-        # This seems a little dirty, but its mostly copied from MCS project.
+        if not timestamp:
+            timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
 
+        # This seems a little dirty, but its mostly copied from MCS project.
         log_s3_filename = (
             folder
             + "/"


### PR DESCRIPTION
I encountered an issue in which a run failed to generate a history file; since we get the timestamp we use for the log filename from the history file, the code that was trying to save the log file was throwing a null exception. In these scenarios, we could simply ignore the log file, but since we might want to review it for information about the failed run, I decided to generate a new timestamp for the log filename instead.